### PR TITLE
feat(Combinatorics/Additive): Sidon sets

### DIFF
--- a/AddCombi.lean
+++ b/AddCombi.lean
@@ -11,5 +11,6 @@ public import AddCombi.Mathlib.Algebra.Notation.Indicator
 public import AddCombi.Mathlib.Algebra.Order.GroupWithZero.Indicator
 public import AddCombi.Mathlib.Algebra.Star.Pi
 public import AddCombi.Mathlib.Combinatorics.Additive.Energy
+public import AddCombi.Mathlib.Combinatorics.Additive.Sidon
 public import AddCombi.Mathlib.Data.Finset.Density
 public import AddCombi.Mathlib.Data.NNRat.Order

--- a/AddCombi/Mathlib/Combinatorics/Additive/Sidon.lean
+++ b/AddCombi/Mathlib/Combinatorics/Additive/Sidon.lean
@@ -23,14 +23,15 @@ pair are not required to be distinct.
 
 * `IsMulSidon` / `IsAddSidon`: the Sidon predicates for a set.
 * `IsMulSidon.mono` / `IsAddSidon.mono`: subsets of Sidon sets are Sidon.
-* `isMulSidon_empty` / `isAddSidon_empty`: the empty set is Sidon.
-* `isMulSidon_singleton` / `isAddSidon_singleton`: singletons are Sidon.
-* `Set.Subsingleton.isMulSidon` / `Set.Subsingleton.isAddSidon`: subsingleton
+* `IsMulSidon.empty` / `IsAddSidon.empty`: the empty set is Sidon.
+* `IsMulSidon.singleton` / `IsAddSidon.singleton`: singletons are Sidon.
+* `IsMulSidon.of_subsingleton` / `IsAddSidon.of_subsingleton`: subsingleton
   sets are Sidon.
-* `isMulSidon_iUnion` / `isAddSidon_iUnion`: directed unions of Sidon sets are
+* `IsMulSidon.iUnion` / `IsAddSidon.iUnion`: directed unions of Sidon sets are
   Sidon.
-* `isMulSidon_pair` / `isAddSidon_pair`: pairs in torsion-free groups are
-  Sidon.
+* `IsMulSidon.sUnion` / `IsAddSidon.sUnion`: directed unions of sets of Sidon
+  sets are Sidon.
+* `IsMulSidon.pair` / `IsAddSidon.pair`: pairs in torsion-free groups are Sidon.
 
 ## Tags
 
@@ -64,30 +65,26 @@ theorem IsMulSidon.mono (hAB : A ⊆ B) (hB : IsMulSidon B) : IsMulSidon A := by
 
 /-- The empty set is Sidon. -/
 @[to_additive (attr := simp)]
-theorem isMulSidon_empty : IsMulSidon (∅ : Set G) := by
+protected theorem IsMulSidon.empty : IsMulSidon (∅ : Set G) := by
   simp [IsMulSidon]
 
 /-- A subsingleton set is Sidon. -/
 @[to_additive]
-theorem Set.Subsingleton.isMulSidon (hA : A.Subsingleton) : IsMulSidon A := by
+theorem IsMulSidon.of_subsingleton (hA : A.Subsingleton) : IsMulSidon A := by
   intro a ha b hb c hc d hd _
   exact Or.inl ⟨hA ha hc, hA hb hd⟩
 
 /-- A singleton is Sidon. -/
 @[to_additive (attr := simp)]
-theorem isMulSidon_singleton (a : G) : IsMulSidon ({a} : Set G) := by
+protected theorem IsMulSidon.singleton (a : G) : IsMulSidon ({a} : Set G) := by
   simp [IsMulSidon]
 
 /-- A directed union of Sidon sets is Sidon. -/
 @[to_additive]
-theorem isMulSidon_iUnion {ι : Sort*} {A : ι → Set G} (hA : Directed (· ⊆ ·) A)
+protected theorem IsMulSidon.iUnion {ι : Sort*} {A : ι → Set G} (hA : Directed (· ⊆ ·) A)
     (h : ∀ i, IsMulSidon (A i)) : IsMulSidon (⋃ i, A i) := by
-  intro a ha b hb c hc d hd hprod
-  rw [Set.mem_iUnion] at ha hb hc hd
-  obtain ⟨i, hai⟩ := ha
-  obtain ⟨j, hbj⟩ := hb
-  obtain ⟨k, hck⟩ := hc
-  obtain ⟨l, hdl⟩ := hd
+  simp only [IsMulSidon, Set.mem_iUnion]
+  rintro a ⟨i, hai⟩ b ⟨j, hbj⟩ c ⟨k, hck⟩ d ⟨l, hdl⟩ hprod
   obtain ⟨ij, hiij, hjij⟩ := hA i j
   obtain ⟨ijk, hijijk, hkijk⟩ := hA ij k
   obtain ⟨ijkl, hijkijkl, hlijkl⟩ := hA ijk l
@@ -96,10 +93,10 @@ theorem isMulSidon_iUnion {ι : Sort*} {A : ι → Set G} (hA : Directed (· ⊆
 
 /-- A directed union of Sidon sets is Sidon. -/
 @[to_additive]
-theorem isMulSidon_sUnion {S : Set (Set G)} (hS : DirectedOn (· ⊆ ·) S)
+protected theorem IsMulSidon.sUnion {S : Set (Set G)} (hS : DirectedOn (· ⊆ ·) S)
     (h : ∀ A ∈ S, IsMulSidon A) : IsMulSidon (⋃₀ S) := by
   rw [Set.sUnion_eq_iUnion]
-  exact isMulSidon_iUnion (directedOn_iff_directed.mp hS) fun A ↦ h A.1 A.2
+  exact IsMulSidon.iUnion (directedOn_iff_directed.mp hS) fun A ↦ h A.1 A.2
 
 end CommMonoid
 
@@ -108,8 +105,8 @@ section CommGroup
 variable [CommGroup G] [IsMulTorsionFree G]
 
 /-- A pair in a torsion-free group is Sidon. -/
-@[to_additive]
-theorem isMulSidon_pair (a b : G) : IsMulSidon ({a, b} : Set G) := by
+@[to_additive /-- A pair in a torsion-free group is Sidon. -/]
+protected theorem IsMulSidon.pair (a b : G) : IsMulSidon ({a, b} : Set G) := by
   intro x hx y hy z hz w hw hprod
   simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hx hy hz hw
   rcases hx with rfl | rfl <;> rcases hy with rfl | rfl <;>

--- a/AddCombi/Mathlib/Combinatorics/Additive/Sidon.lean
+++ b/AddCombi/Mathlib/Combinatorics/Additive/Sidon.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2026 David B. Hulak. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: David B. Hulak
+-/
+module
+
+public import Mathlib.Algebra.Group.Defs
+public import Mathlib.Data.Set.Insert
+
+/-!
+# Sidon sets
+
+This file defines the predicate `IsSidon` for sets in an additive commutative
+monoid. A set is Sidon if whenever `a + b = c + d` for elements `a`, `b`, `c`,
+`d` of the set, then either `a = c` and `b = d`, or `a = d` and `b = c`. The
+two elements in each pair are not required to be distinct.
+
+## Main declarations
+
+* `IsSidon`: the Sidon predicate for a set.
+* `IsSidon.mono`: subsets of Sidon sets are Sidon.
+* `IsSidon.empty`: the empty set is Sidon.
+* `IsSidon.singleton`: every singleton is Sidon.
+
+## Tags
+
+Sidon set, additive combinatorics
+-/
+
+public section
+
+variable {G : Type*} [AddCommMonoid G]
+
+/-- A set `A` is Sidon if whenever `a + b = c + d` for elements `a`, `b`, `c`,
+`d` of `A`, then either `a = c` and `b = d`, or `a = d` and `b = c`. The two
+elements in each pair are not required to be distinct. -/
+def IsSidon (A : Set G) : Prop :=
+  ∀ ⦃a b c d : G⦄, a ∈ A → b ∈ A → c ∈ A → d ∈ A →
+    a + b = c + d → (a = c ∧ b = d) ∨ (a = d ∧ b = c)
+
+/-- A subset of a Sidon set is Sidon. -/
+theorem IsSidon.mono {A B : Set G} (hB : IsSidon B) (hAB : A ⊆ B) :
+    IsSidon A := by
+  intro a b c d ha hb hc hd hsum
+  exact hB (hAB ha) (hAB hb) (hAB hc) (hAB hd) hsum
+
+/-- The empty set is Sidon. -/
+@[simp]
+theorem IsSidon.empty : IsSidon (∅ : Set G) := by
+  intro a b c d ha
+  cases ha
+
+/-- A singleton is Sidon. -/
+@[simp]
+theorem IsSidon.singleton (a : G) : IsSidon ({a} : Set G) := by
+  intro b c d e hb hc hd he _
+  subst b
+  subst c
+  subst d
+  subst e
+  exact Or.inl ⟨rfl, rfl⟩

--- a/AddCombi/Mathlib/Combinatorics/Additive/Sidon.lean
+++ b/AddCombi/Mathlib/Combinatorics/Additive/Sidon.lean
@@ -12,16 +12,19 @@ public import Mathlib.Data.Set.Insert
 /-!
 # Sidon sets
 
-This file defines the predicates `IsMulSidon` and `IsAddSidon` for sets in
-commutative monoids. A set is additively Sidon if whenever `a + b = c + d` for
-elements `a`, `b`, `c`, `d` of the set, then either `a = c` and `b = d`, or
-`a = d` and `b = c`. The two elements in each pair are not required to be
-distinct.
+This file defines the multiplicative predicate `IsMulSidon` for sets in
+commutative monoids, and the additive predicate `IsAddSidon` generated from it.
+A set is multiplicatively Sidon if whenever `a * b = c * d` for elements `a`,
+`b`, `c`, `d` of the set, then either `a = c` and `b = d`, or `a = d` and
+`b = c`. Additively, products are replaced by sums. The two elements in each
+pair are not required to be distinct.
 
 ## Main declarations
 
 * `IsMulSidon` / `IsAddSidon`: the Sidon predicates for a set.
 * `IsMulSidon.mono` / `IsAddSidon.mono`: subsets of Sidon sets are Sidon.
+* `isMulSidon_empty` / `isAddSidon_empty`: the empty set is Sidon.
+* `isMulSidon_singleton` / `isAddSidon_singleton`: singletons are Sidon.
 * `Set.Subsingleton.isMulSidon` / `Set.Subsingleton.isAddSidon`: subsingleton
   sets are Sidon.
 * `isMulSidon_iUnion` / `isAddSidon_iUnion`: directed unions of Sidon sets are
@@ -38,6 +41,9 @@ public section
 
 variable {G : Type*}
 
+/-- A set `A` is multiplicatively Sidon if whenever `a * b = c * d` for elements
+`a`, `b`, `c`, `d` of `A`, then either `a = c` and `b = d`, or `a = d` and
+`b = c`. The two elements in each pair are not required to be distinct. -/
 @[to_additive
 /-- A set `A` is additively Sidon if whenever `a + b = c + d` for elements
 `a`, `b`, `c`, `d` of `A`, then either `a = c` and `b = d`, or `a = d` and

--- a/AddCombi/Mathlib/Combinatorics/Additive/Sidon.lean
+++ b/AddCombi/Mathlib/Combinatorics/Additive/Sidon.lean
@@ -5,23 +5,29 @@ Authors: David B. Hulak
 -/
 module
 
-public import Mathlib.Algebra.Group.Defs
+public import Mathlib.Algebra.Group.Torsion
+public import Mathlib.Data.Set.Lattice
 public import Mathlib.Data.Set.Insert
 
 /-!
 # Sidon sets
 
-This file defines the predicate `IsSidon` for sets in an additive commutative
-monoid. A set is Sidon if whenever `a + b = c + d` for elements `a`, `b`, `c`,
-`d` of the set, then either `a = c` and `b = d`, or `a = d` and `b = c`. The
-two elements in each pair are not required to be distinct.
+This file defines the predicates `IsMulSidon` and `IsAddSidon` for sets in
+commutative monoids. A set is additively Sidon if whenever `a + b = c + d` for
+elements `a`, `b`, `c`, `d` of the set, then either `a = c` and `b = d`, or
+`a = d` and `b = c`. The two elements in each pair are not required to be
+distinct.
 
 ## Main declarations
 
-* `IsSidon`: the Sidon predicate for a set.
-* `IsSidon.mono`: subsets of Sidon sets are Sidon.
-* `IsSidon.empty`: the empty set is Sidon.
-* `IsSidon.singleton`: every singleton is Sidon.
+* `IsMulSidon` / `IsAddSidon`: the Sidon predicates for a set.
+* `IsMulSidon.mono` / `IsAddSidon.mono`: subsets of Sidon sets are Sidon.
+* `Set.Subsingleton.isMulSidon` / `Set.Subsingleton.isAddSidon`: subsingleton
+  sets are Sidon.
+* `isMulSidon_iUnion` / `isAddSidon_iUnion`: directed unions of Sidon sets are
+  Sidon.
+* `isMulSidon_pair` / `isAddSidon_pair`: pairs in torsion-free groups are
+  Sidon.
 
 ## Tags
 
@@ -30,33 +36,81 @@ Sidon set, additive combinatorics
 
 public section
 
-variable {G : Type*} [AddCommMonoid G]
+variable {G : Type*}
 
-/-- A set `A` is Sidon if whenever `a + b = c + d` for elements `a`, `b`, `c`,
-`d` of `A`, then either `a = c` and `b = d`, or `a = d` and `b = c`. The two
-elements in each pair are not required to be distinct. -/
-def IsSidon (A : Set G) : Prop :=
-  ∀ ⦃a b c d : G⦄, a ∈ A → b ∈ A → c ∈ A → d ∈ A →
-    a + b = c + d → (a = c ∧ b = d) ∨ (a = d ∧ b = c)
+@[to_additive
+/-- A set `A` is additively Sidon if whenever `a + b = c + d` for elements
+`a`, `b`, `c`, `d` of `A`, then either `a = c` and `b = d`, or `a = d` and
+`b = c`. The two elements in each pair are not required to be distinct. -/]
+def IsMulSidon [CommMonoid G] (A : Set G) : Prop :=
+  ∀ ⦃a : G⦄, a ∈ A → ∀ ⦃b : G⦄, b ∈ A → ∀ ⦃c : G⦄, c ∈ A → ∀ ⦃d : G⦄,
+    d ∈ A → a * b = c * d → a = c ∧ b = d ∨ a = d ∧ b = c
+
+section CommMonoid
+
+variable [CommMonoid G] {A B : Set G}
 
 /-- A subset of a Sidon set is Sidon. -/
-theorem IsSidon.mono {A B : Set G} (hB : IsSidon B) (hAB : A ⊆ B) :
-    IsSidon A := by
-  intro a b c d ha hb hc hd hsum
-  exact hB (hAB ha) (hAB hb) (hAB hc) (hAB hd) hsum
+@[to_additive (attr := gcongr), gcongr]
+theorem IsMulSidon.mono (hAB : A ⊆ B) (hB : IsMulSidon B) : IsMulSidon A := by
+  intro a ha b hb c hc d hd hprod
+  exact hB (hAB ha) (hAB hb) (hAB hc) (hAB hd) hprod
 
 /-- The empty set is Sidon. -/
-@[simp]
-theorem IsSidon.empty : IsSidon (∅ : Set G) := by
-  intro a b c d ha
-  cases ha
+@[to_additive (attr := simp)]
+theorem isMulSidon_empty : IsMulSidon (∅ : Set G) := by
+  simp [IsMulSidon]
+
+/-- A subsingleton set is Sidon. -/
+@[to_additive]
+theorem Set.Subsingleton.isMulSidon (hA : A.Subsingleton) : IsMulSidon A := by
+  intro a ha b hb c hc d hd _
+  exact Or.inl ⟨hA ha hc, hA hb hd⟩
 
 /-- A singleton is Sidon. -/
-@[simp]
-theorem IsSidon.singleton (a : G) : IsSidon ({a} : Set G) := by
-  intro b c d e hb hc hd he _
-  subst b
-  subst c
-  subst d
-  subst e
-  exact Or.inl ⟨rfl, rfl⟩
+@[to_additive (attr := simp)]
+theorem isMulSidon_singleton (a : G) : IsMulSidon ({a} : Set G) := by
+  simp [IsMulSidon]
+
+/-- A directed union of Sidon sets is Sidon. -/
+@[to_additive]
+theorem isMulSidon_iUnion {ι : Sort*} {A : ι → Set G} (hA : Directed (· ⊆ ·) A)
+    (h : ∀ i, IsMulSidon (A i)) : IsMulSidon (⋃ i, A i) := by
+  intro a ha b hb c hc d hd hprod
+  rw [Set.mem_iUnion] at ha hb hc hd
+  obtain ⟨i, hai⟩ := ha
+  obtain ⟨j, hbj⟩ := hb
+  obtain ⟨k, hck⟩ := hc
+  obtain ⟨l, hdl⟩ := hd
+  obtain ⟨ij, hiij, hjij⟩ := hA i j
+  obtain ⟨ijk, hijijk, hkijk⟩ := hA ij k
+  obtain ⟨ijkl, hijkijkl, hlijkl⟩ := hA ijk l
+  exact h ijkl (hijkijkl (hijijk (hiij hai))) (hijkijkl (hijijk (hjij hbj)))
+    (hijkijkl (hkijk hck)) (hlijkl hdl) hprod
+
+/-- A directed union of Sidon sets is Sidon. -/
+@[to_additive]
+theorem isMulSidon_sUnion {S : Set (Set G)} (hS : DirectedOn (· ⊆ ·) S)
+    (h : ∀ A ∈ S, IsMulSidon A) : IsMulSidon (⋃₀ S) := by
+  rw [Set.sUnion_eq_iUnion]
+  exact isMulSidon_iUnion (directedOn_iff_directed.mp hS) fun A ↦ h A.1 A.2
+
+end CommMonoid
+
+section CommGroup
+
+variable [CommGroup G] [IsMulTorsionFree G]
+
+/-- A pair in a torsion-free group is Sidon. -/
+@[to_additive]
+theorem isMulSidon_pair (a b : G) : IsMulSidon ({a, b} : Set G) := by
+  intro x hx y hy z hz w hw hprod
+  simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hx hy hz hw
+  rcases hx with rfl | rfl <;> rcases hy with rfl | rfl <;>
+    rcases hz with rfl | rfl <;> rcases hw with rfl | rfl
+  all_goals
+    simp_all only [and_self, or_self, true_or, or_true, mul_left_cancel_iff,
+      mul_right_cancel_iff]
+  all_goals exact (pow_left_inj (show (2 : ℕ) ≠ 0 by decide)).1 (by simpa [sq] using hprod)
+
+end CommGroup

--- a/AddCombi/Mathlib/Combinatorics/Additive/Sidon.lean
+++ b/AddCombi/Mathlib/Combinatorics/Additive/Sidon.lean
@@ -70,7 +70,7 @@ protected theorem IsMulSidon.empty : IsMulSidon (∅ : Set G) := by
 
 /-- A subsingleton set is Sidon. -/
 @[to_additive]
-theorem IsMulSidon.of_subsingleton (hA : A.Subsingleton) : IsMulSidon A := by
+protected theorem IsMulSidon.of_subsingleton (hA : A.Subsingleton) : IsMulSidon A := by
   intro a ha b hb c hc d hd _
   exact Or.inl ⟨hA ha hc, hA hb hd⟩
 

--- a/AddCombi/Mathlib/Combinatorics/Additive/Sidon.lean
+++ b/AddCombi/Mathlib/Combinatorics/Additive/Sidon.lean
@@ -21,17 +21,7 @@ pair are not required to be distinct.
 
 ## Main declarations
 
-* `IsMulSidon` / `IsAddSidon`: the Sidon predicates for a set.
-* `IsMulSidon.mono` / `IsAddSidon.mono`: subsets of Sidon sets are Sidon.
-* `IsMulSidon.empty` / `IsAddSidon.empty`: the empty set is Sidon.
-* `IsMulSidon.singleton` / `IsAddSidon.singleton`: singletons are Sidon.
-* `IsMulSidon.of_subsingleton` / `IsAddSidon.of_subsingleton`: subsingleton
-  sets are Sidon.
-* `IsMulSidon.iUnion` / `IsAddSidon.iUnion`: directed unions of Sidon sets are
-  Sidon.
-* `IsMulSidon.sUnion` / `IsAddSidon.sUnion`: directed unions of sets of Sidon
-  sets are Sidon.
-* `IsMulSidon.pair` / `IsAddSidon.pair`: pairs in torsion-free groups are Sidon.
+* `IsMulSidon`/`IsAddSidon`: Predicates for a set to be Sidon.
 
 ## Tags
 
@@ -58,29 +48,29 @@ section CommMonoid
 variable [CommMonoid G] {A B : Set G}
 
 /-- A subset of a Sidon set is Sidon. -/
-@[to_additive (attr := gcongr), gcongr]
+@[to_additive (attr := gcongr) /-- A subset of an additive Sidon set is Sidon. -/, gcongr]
 theorem IsMulSidon.mono (hAB : A ⊆ B) (hB : IsMulSidon B) : IsMulSidon A := by
   intro a ha b hb c hc d hd hprod
   exact hB (hAB ha) (hAB hb) (hAB hc) (hAB hd) hprod
 
 /-- The empty set is Sidon. -/
-@[to_additive (attr := simp)]
+@[to_additive (attr := simp) /-- The empty set is additively Sidon. -/]
 protected theorem IsMulSidon.empty : IsMulSidon (∅ : Set G) := by
   simp [IsMulSidon]
 
 /-- A subsingleton set is Sidon. -/
-@[to_additive]
+@[to_additive /-- A subsingleton set is additively Sidon. -/]
 protected theorem IsMulSidon.of_subsingleton (hA : A.Subsingleton) : IsMulSidon A := by
   intro a ha b hb c hc d hd _
   exact Or.inl ⟨hA ha hc, hA hb hd⟩
 
 /-- A singleton is Sidon. -/
-@[to_additive (attr := simp)]
+@[to_additive (attr := simp) /-- A singleton is additively Sidon. -/]
 protected theorem IsMulSidon.singleton (a : G) : IsMulSidon ({a} : Set G) := by
   simp [IsMulSidon]
 
 /-- A directed union of Sidon sets is Sidon. -/
-@[to_additive]
+@[to_additive /-- A directed union of additively Sidon sets is additively Sidon. -/]
 protected theorem IsMulSidon.iUnion {ι : Sort*} {A : ι → Set G} (hA : Directed (· ⊆ ·) A)
     (h : ∀ i, IsMulSidon (A i)) : IsMulSidon (⋃ i, A i) := by
   simp only [IsMulSidon, Set.mem_iUnion]
@@ -92,7 +82,7 @@ protected theorem IsMulSidon.iUnion {ι : Sort*} {A : ι → Set G} (hA : Direct
     (hijkijkl (hkijk hck)) (hlijkl hdl) hprod
 
 /-- A directed union of Sidon sets is Sidon. -/
-@[to_additive]
+@[to_additive /-- A directed union of additively Sidon sets is additively Sidon. -/]
 protected theorem IsMulSidon.sUnion {S : Set (Set G)} (hS : DirectedOn (· ⊆ ·) S)
     (h : ∀ A ∈ S, IsMulSidon A) : IsMulSidon (⋃₀ S) := by
   rw [Set.sUnion_eq_iUnion]

--- a/AddCombi/Mathlib/Combinatorics/Additive/Sidon.lean
+++ b/AddCombi/Mathlib/Combinatorics/Additive/Sidon.lean
@@ -48,7 +48,8 @@ section CommMonoid
 variable [CommMonoid G] {A B : Set G}
 
 /-- A subset of a Sidon set is Sidon. -/
-@[to_additive (attr := gcongr) /-- A subset of an additive Sidon set is Sidon. -/, gcongr]
+@[to_additive (attr := gcongr) /-- A subset of an additively Sidon set is additively Sidon. -/,
+  gcongr]
 theorem IsMulSidon.mono (hAB : A ⊆ B) (hB : IsMulSidon B) : IsMulSidon A := by
   intro a ha b hb c hc d hd hprod
   exact hB (hAB ha) (hAB hb) (hAB hc) (hAB hd) hprod
@@ -95,7 +96,7 @@ section CommGroup
 variable [CommGroup G] [IsMulTorsionFree G]
 
 /-- A pair in a torsion-free group is Sidon. -/
-@[to_additive /-- A pair in a torsion-free group is Sidon. -/]
+@[to_additive /-- A pair in a torsion-free group is additively Sidon. -/]
 protected theorem IsMulSidon.pair (a b : G) : IsMulSidon ({a, b} : Set G) := by
   intro x hx y hy z hz w hw hprod
   simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hx hy hz hw

--- a/AddCombi/Mathlib/Combinatorics/Additive/Sidon.lean
+++ b/AddCombi/Mathlib/Combinatorics/Additive/Sidon.lean
@@ -48,8 +48,7 @@ section CommMonoid
 variable [CommMonoid G] {A B : Set G}
 
 /-- A subset of a Sidon set is Sidon. -/
-@[to_additive (attr := gcongr) /-- A subset of an additively Sidon set is additively Sidon. -/,
-  gcongr]
+@[to_additive (attr := gcongr) /-- A subset of an additively Sidon set is additively Sidon. -/]
 theorem IsMulSidon.mono (hAB : A ⊆ B) (hB : IsMulSidon B) : IsMulSidon A := by
   intro a ha b hb c hc d hd hprod
   exact hB (hAB ha) (hAB hb) (hAB hc) (hAB hd) hprod

--- a/AddCombi/Mathlib/Combinatorics/Additive/Sidon.lean
+++ b/AddCombi/Mathlib/Combinatorics/Additive/Sidon.lean
@@ -86,7 +86,7 @@ protected theorem IsMulSidon.iUnion {ι : Sort*} {A : ι → Set G} (hA : Direct
 protected theorem IsMulSidon.sUnion {S : Set (Set G)} (hS : DirectedOn (· ⊆ ·) S)
     (h : ∀ A ∈ S, IsMulSidon A) : IsMulSidon (⋃₀ S) := by
   rw [Set.sUnion_eq_iUnion]
-  exact IsMulSidon.iUnion (directedOn_iff_directed.mp hS) fun A ↦ h A.1 A.2
+  exact .iUnion hS.directed_val fun A ↦ h A.1 A.2
 
 end CommMonoid
 

--- a/AddCombi/Mathlib/Combinatorics/Additive/Sidon.lean
+++ b/AddCombi/Mathlib/Combinatorics/Additive/Sidon.lean
@@ -62,7 +62,7 @@ protected theorem IsMulSidon.empty : IsMulSidon (∅ : Set G) := by
 @[to_additive /-- A subsingleton set is additively Sidon. -/]
 protected theorem IsMulSidon.of_subsingleton (hA : A.Subsingleton) : IsMulSidon A := by
   intro a ha b hb c hc d hd _
-  exact Or.inl ⟨hA ha hc, hA hb hd⟩
+  exact .inl ⟨hA ha hc, hA hb hd⟩
 
 /-- A singleton is Sidon. -/
 @[to_additive (attr := simp) /-- A singleton is additively Sidon. -/]


### PR DESCRIPTION
Add small Sidon predicates for sets in commutative monoids.

The multiplicative predicate is `IsMulSidon` over `[CommMonoid G]`; the additive predicate `IsAddSidon` is generated from it with `@[to_additive]`. Multiplicatively, the predicate says that whenever `a * b = c * d` for elements `a`, `b`, `c`, `d` of the set, then either `a = c` and `b = d`, or `a = d` and `b = c`. Additively, products are replaced by sums. The two elements in each pair are not required to be distinct.

This provides a small `Set`-based Sidon API in AddCombi. It adds monotonicity, empty and singleton cases, subsingleton sets, directed `iUnion` and `sUnion` lemmas, and two-element-set pair lemmas in torsion-free groups.

Zulip discussion: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/AddCombi.20PR.20for.20Sidon.20sets/with/594873478. This PR started from the Sidon API discussed there and incorporates follow-ups for subsingletons, directed unions, and pair lemmas.

## AI use

GitHub Copilot CLI was used to help draft and check this change. I reviewed it for scope and consistency with the Sidon API proposal.

## Validation

- `lake build AddCombi.Mathlib.Combinatorics.Additive.Sidon`
- `lake exe mk_all` with unrelated `module -- shake: keep-all` churn restored
- `lake env lean /tmp/sidon_final_checks.lean` for generated additive API signatures, generated docstrings, `gcongr` behavior examples, `docBlame`, and `simpNF`
- `lake build AddCombi`
- `lake build`
- `git diff --check`
- warning/error/sorry/admit/docBlame/simpNF scan over validation logs